### PR TITLE
Making APIs RESTful

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Mac:
 
 ### Flow of Spotify OAuth Authorization Endpoints: 
 - [Visualization of Spotify API Authorization](https://developer-assets.spotifycdn.com/images/documentation/web-api/auth-code-flow.png)
-  1) Call GET `/api/v1/spotify/login` will direct user to Spotify and ask them to authorize
-  2) Once authorized, user will be redirected to `/api/v1/spotify/callback` with an authentication code in the uri query parameter (e.g. `/api/v1/spotify/callback?code={whatevercodehere`)
-  3) GET `api/v1/spotify/callback` will automatically return the auth code (no need to call it) from it's the query parameter after user is redirected here from step 1
-  4) Call POST `api/v1/spotify/token` with auth code (received in step 3) in the body, should receive access token
-  5) Authorization done! Use the access token for all futuer Spotify API calls
+  1) Call GET `/api/v1/spotify/auth`, this endpoint will send the client to Spotify and ask them to authorize their account
+  2) Once authorized, client will be redirected to `/api/v1/spotify/callback`, this endpoint will return the authorization code in the url's query parameter (e.g. `/api/v1/spotify/callback?code={whatevercodehere`) 
+     - Note: Don't need to call GET `/api/v1/spotify/callback`, user is automatically redirected here after authorizing through Spotify
+  3) Call POST `/api/v1/spotify/token` with auth code (received in step 3) in the body, should receive access token
+  4) Authorization done! Use the access token for all future Spotify API calls

--- a/src/main/java/nack2/tunes/spotify/SpotifyController.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyController.java
@@ -34,24 +34,41 @@ public class SpotifyController {
     @GetMapping(path="callback")
     public HttpEntity<Map<String, String>> getAuthCode(HttpServletRequest request) {
         Map<String, String> result = new HashMap<>();
+        result.put("path", "/api/v1/spotify/callback");
 
         try {
             String authCode = spotifyService.getAuthCode(request);
             result.put("authCode", authCode);
+            result.put("status", HttpStatus.OK.toString());
             return ResponseEntity.status(HttpStatus.OK).body(result);
         } catch(Exception e) {
             result.put("error", e.getMessage());
+            result.put("status", HttpStatus.BAD_REQUEST.toString());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
         }
     }
 
 
     @PostMapping(path="token")
-    public ResponseEntity<Map<String, String>> getAccessToken(@RequestBody String authCode) {
-        String accessToken = spotifyService.getAccessToken(authCode);
+    public ResponseEntity<Map<String, String>> getAccessToken(@RequestBody Map<String, String> authCode) {
         Map<String, String> result = new HashMap<>();
-        result.put("accessToken", accessToken);
+        result.put("path", "/api/v1/spotify/token");
 
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+        if (!authCode.containsKey("authCode")) {
+            result.put("error", "Missing authCode in body");
+            result.put("status", HttpStatus.BAD_REQUEST.toString());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+        }
+
+        try {
+            String accessToken = spotifyService.getAccessToken(authCode);
+            result.put("accessToken", accessToken);
+            result.put("status", HttpStatus.OK.toString());
+            return ResponseEntity.status(HttpStatus.OK).body(result);
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+            result.put("status", HttpStatus.BAD_REQUEST.toString());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+        }
     }
 }

--- a/src/main/java/nack2/tunes/spotify/SpotifyController.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyController.java
@@ -4,7 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping(path = "spotify")
@@ -18,7 +22,7 @@ public class SpotifyController {
 
     // OAuth flow: https://developer-assets.spotifycdn.com/images/documentation/web-api/auth-code-flow.png
 
-    @GetMapping(path="login")
+    @GetMapping(path="auth")
     public void login(HttpServletResponse response) {
         spotifyService.authorizeLogin(response);
     }
@@ -29,7 +33,11 @@ public class SpotifyController {
     }
 
     @PostMapping(path="token")
-    public HttpEntity<String> getAccessToken(@RequestBody String authCode) {
-        return spotifyService.getAccessToken(authCode);
+    public ResponseEntity<Map<String, String>> getAccessToken(@RequestBody String authCode) {
+        String accessToken = spotifyService.getAccessToken(authCode);
+        Map<String, String> result = new HashMap<>();
+        result.put("accessToken", accessToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 }

--- a/src/main/java/nack2/tunes/spotify/SpotifyController.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyController.java
@@ -23,18 +23,18 @@ public class SpotifyController {
     // OAuth flow: https://developer-assets.spotifycdn.com/images/documentation/web-api/auth-code-flow.png
 
     @GetMapping(path="auth")
-    public ResponseEntity<Map<String, String>> getAuthUrl() {
+    public ResponseEntity<Map<String, String>> getAuthUrlAndState() {
         Map<String, String> result = new HashMap<>();
         result.put("path", "/api/v1/spotify/auth");
+        String state = spotifyService.getState();
         String authUrl = spotifyService.getAuthUrl();
         result.put("authUrl", authUrl);
+        result.put("state", state);
         result.put("status", HttpStatus.OK.toString());
 
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    // GET /callback shouldn't be called by client, client will be redirected
-    // here automatically after granting authorization at GET /auth
     @GetMapping(path="callback")
     public HttpEntity<Map<String, String>> getAuthCode(HttpServletRequest request) {
         Map<String, String> result = new HashMap<>();

--- a/src/main/java/nack2/tunes/spotify/SpotifyController.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
 
+@CrossOrigin(origins = "http://localhost:5173/")
 @RestController
 @RequestMapping(path = "spotify")
 public class SpotifyController {
@@ -22,11 +23,14 @@ public class SpotifyController {
     // OAuth flow: https://developer-assets.spotifycdn.com/images/documentation/web-api/auth-code-flow.png
 
     @GetMapping(path="auth")
-    public ResponseEntity<Map<String, String>> authorize() {
+    public ResponseEntity<Map<String, String>> getAuthUrl() {
+        Map<String, String> result = new HashMap<>();
+        result.put("path", "/api/v1/spotify/auth");
         String authUrl = spotifyService.getAuthUrl();
+        result.put("authUrl", authUrl);
+        result.put("status", HttpStatus.OK.toString());
 
-        // client redirected to authUrl
-        return ResponseEntity.status(HttpStatus.FOUND).header("Location", authUrl).build();
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     // GET /callback shouldn't be called by client, client will be redirected

--- a/src/main/java/nack2/tunes/spotify/SpotifyService.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyService.java
@@ -27,19 +27,22 @@ public class SpotifyService {
     @Value("${api.base-url}")
     private String API_BASE_URL;
 
-    private String state;
+    private final String state = UUID.randomUUID().toString();
+
+    public String getState() {
+        return this.state;
+    }
 
     public String getAuthUrl() {
-        String redirectUrl = API_BASE_URL + "/spotify/callback";
+        String redirectUrl = "http://localhost:5173/";
         String scope = "app-remote-control";
-        this.state = UUID.randomUUID().toString();
 
         String authUrl = "https://accounts.spotify.com/authorize?" +
                 "response_type=code" +
-                "&client_id=" + clientId +
+                "&client_id=" + this.clientId +
                 "&scope=" + scope +
                 "&redirect_uri=" + redirectUrl+
-                "&state=" + state;
+                "&state=" + this.state;
 
         return authUrl;
     }

--- a/src/main/java/nack2/tunes/spotify/SpotifyService.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyService.java
@@ -1,10 +1,11 @@
 package nack2.tunes.spotify;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -27,7 +28,7 @@ public class SpotifyService {
 
     private String state;
 
-    public void authorizeLogin(HttpServletResponse response) {
+    public String getAuthUrl() {
         String redirectUrl = API_BASE_URL + "/spotify/callback";
         String scope = "app-remote-control";
         this.state = UUID.randomUUID().toString();
@@ -39,22 +40,20 @@ public class SpotifyService {
                 "&redirect_uri=" + redirectUrl+
                 "&state=" + state;
 
-        // direct user to spotify authorize url
-        response.setHeader("Location", authUrl);
-        response.setStatus(HttpServletResponse.SC_FOUND);
+        return authUrl;
     }
 
-    public ResponseEntity<String> getAuthCode(HttpServletRequest request){
+    public String getAuthCode(HttpServletRequest request) throws Exception {
         String code = request.getParameter("code");
         String state = request.getParameter("state");
 
         if (code == null || code.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Authorization code is missing");
+            throw new Exception("Authorization code is missing");
         } else if (!this.state.equals(state)) {
-            ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid state");
+            throw new Exception("Invalid state");
         }
 
-        return ResponseEntity.ok(code);
+        return code;
     }
 
     public String getAccessToken(String authCode) {

--- a/src/main/java/nack2/tunes/spotify/SpotifyService.java
+++ b/src/main/java/nack2/tunes/spotify/SpotifyService.java
@@ -57,7 +57,7 @@ public class SpotifyService {
         return ResponseEntity.ok(code);
     }
 
-    public ResponseEntity<String> getAccessToken(String authCode) {
+    public String getAccessToken(String authCode) {
         String url = "https://accounts.spotify.com/api/token";
         String redirectUrl = API_BASE_URL + "/spotify/callback";
 
@@ -66,19 +66,15 @@ public class SpotifyService {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.setBasicAuth(base64Credentials) ;
+        headers.setBasicAuth(base64Credentials);
 
-//        String body = "grant_type=client_credentials&client_id="+ clientId + "&client_secret=" + clientSecret;
         String body = "grant_type=authorization_code&code="+ authCode + "&redirect_uri=" + redirectUrl;
 
         HttpEntity<String> entity = new HttpEntity<>(body, headers);
 
         RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> result = restTemplate.postForEntity(url, entity, String.class); // entity contains entire response; msg, code, etc.
+        String result = restTemplate.postForObject(url, entity, String.class);
 
-        JSONObject resultJson = new JSONObject(result.getBody());
-        String accessToken = resultJson.getString("access_token");
-
-        return ResponseEntity.ok(accessToken);
+        return new JSONObject(result).getString("access_token");
     }
 }


### PR DESCRIPTION
Making our spotify authorization apis restful

- `/api/v1/spotify/login` name change -> `/api/v1/spotify/auth`
- Made changes to `/api/v1/spotify/auth`, `/api/v1/spotify/callback`, `/api/v1/spotify/token`
    - Returning restful responses from api endpoints in `SpotifyController.java`:
    200 success response example:
    ```
    {
    "path": "/api/v1/spotify/token",
    "accessToken": "whatever access token here",
    "status": "200 OK"
    }
    ```
    
    400/500 error response example:
    ```
    {
    "path": "/api/v1/spotify/callback",
    "error": "whatever error message here",
    "status": "BAD_REQUEST OK"
    }
    ```
    - `SpotifyService.java` is performing business logic and returning either expected value or exception if spotify api call fails